### PR TITLE
Prefix preserving IP enc

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,24 @@
+name: Go
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,3 +22,9 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Benchmark prefix preserving IP address encryption
+      run: go test -bench BenchmarkPanIp* -run=^$
+    
+    - name: Benchmark ipcipher IP address encryption
+      run: go test -bench BenchmarkEncrypt* -run=^$

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,8 @@ name: Go
 on:
   push:
   pull_request:
-    branches: [ master ]
+    types: [closed]
+  workflow_dispatch:
 
 jobs:
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ GO_SRC := $(wildcard *.go)
 
 ifeq ($(debug),on)
 	LDFLAGS := -ldflags="-X github.com/intuitivelabs/anonymization.Debug=on"
+	TAGS := -tags debug
 endif
 
 ifdef tests
@@ -17,10 +18,10 @@ endif
 all: build
 
 test: $(GO_SRC)
-	go test $(LDFLAGS) $(RUNFLAGS)
+	go test $(TAGS) $(LDFLAGS) $(RUNFLAGS)
 
 build: $(GO_SRC)
-	@go build $(LDFLAGS) ./...
+	@go build $(TAGS) $(LDFLAGS) ./...
 
 install: $(GO_SRC)
 	@go install

--- a/anonym-ip_test.go
+++ b/anonym-ip_test.go
@@ -347,3 +347,26 @@ func TestEncrypt(t *testing.T) {
 func TestDecrypt(t *testing.T) {
 	TestEncrypt(t)
 }
+
+func BenchmarkEncryptIP(b *testing.B) {
+	// set-up if needed
+	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
+	b.Run("IPv4, passphrase", func(b *testing.B) {
+		cases := []net.IP{
+			[]byte{1, 2, 3, 4},
+			//[]byte{198, 41, 56, 22},
+			//[]byte{22, 11, 33, 44},
+			//[]byte{255, 0, 255, 241},
+		}
+		var enc net.IP
+		enc = make([]byte, net.IPv4len)
+		b.ResetTimer()
+		for _, c := range cases {
+			for i := 0; i < b.N; i++ {
+				if err := EncryptIP(key, enc, c); err != nil {
+					b.Fatalf("encryption error %s for IP %s", err, c.String())
+				}
+			}
+		}
+	})
+}

--- a/blockModeCipher.go
+++ b/blockModeCipher.go
@@ -32,7 +32,7 @@ func (bm *BlockModeCipher) Reset() {
 func cbcEncryptToken(dst, src []byte, pf sipsp.PField, encrypter cipher.BlockMode) (length int, err error) {
 	df := DbgOn()
 	defer DbgRestore(df)
-	Dbg("src: %v len: %d offset: %d len: %d", src, len(src), pf.Offs, pf.Len)
+	_ = WithDebug && Dbg("src: %v len: %d offset: %d len: %d", src, len(src), pf.Offs, pf.Len)
 	token := pf.Get(src)
 	// 1. copy token
 	_ = copy(dst, token)
@@ -46,10 +46,10 @@ func cbcEncryptToken(dst, src []byte, pf sipsp.PField, encrypter cipher.BlockMod
 	if err != nil {
 		return 0, fmt.Errorf("token encryption error: %w", err)
 	}
-	Dbg("padded eToken: %v", eToken)
+	_ = WithDebug && Dbg("padded eToken: %v", eToken)
 	// 3. encrypt token
 	encrypter.CryptBlocks(eToken, eToken)
-	Dbg("encrypted eToken: %v (len: %d)", eToken, len(eToken))
+	_ = WithDebug && Dbg("encrypted eToken: %v (len: %d)", eToken, len(eToken))
 	return len(eToken), nil
 }
 

--- a/call-id.go
+++ b/call-id.go
@@ -41,7 +41,7 @@ func InitCallIdKeys(iv []byte, k []byte) {
 	copy(GetCallIdKeys().Key[:], k)
 }
 
-func InitCallIdKeysFromMasterKey(masterKey []byte, keyLen int) {
+func InitCallIdKeysFromMasterKey(masterKey []byte) {
 	df := DbgOn()
 	defer DbgRestore(df)
 	// generate Call-ID IV for CBC

--- a/call-id.go
+++ b/call-id.go
@@ -46,10 +46,10 @@ func InitCallIdKeysFromMasterKey(masterKey []byte) {
 	defer DbgRestore(df)
 	// generate Call-ID IV for CBC
 	GenerateCallIdIV(masterKey[:], EncryptionKeyLen, GetCallIdKeys().IV[:])
-	Dbg("Call-ID IV: %v", GetCallIdKeys().IV)
+	_ = WithDebug && Dbg("Call-ID IV: %v", GetCallIdKeys().IV)
 	// generate key for Call-ID
 	GenerateCallIdKey(masterKey[:], EncryptionKeyLen, GetCallIdKeys().Key[:])
-	Dbg("Call-ID Key: %v", GetCallIdKeys().Key)
+	_ = WithDebug && Dbg("Call-ID Key: %v", GetCallIdKeys().Key)
 }
 
 func NewCallIdCBC(keys *CallIdKeys) *BlockModeCipher {

--- a/call-id_test.go
+++ b/call-id_test.go
@@ -141,7 +141,7 @@ func TestCallIdAnonymization(t *testing.T) {
 	GenerateKeyFromPassphraseAndCopy(pass, EncryptionKeyLen, encKey[:])
 
 	// initialize the URI CBC based encryption
-	InitCallIdKeysFromMasterKey(encKey[:], EncryptionKeyLen)
+	InitCallIdKeysFromMasterKey(encKey[:])
 	NewCallIdCBC(GetCallIdKeys())
 	// test case data
 	callIds := [...][]byte{

--- a/call-id_test.go
+++ b/call-id_test.go
@@ -40,25 +40,25 @@ func TestCallIdBase32Codec(t *testing.T) {
 	// tests
 	t.Run("dynamic memory", func(t *testing.T) {
 		for i, c := range pCallIds {
-			Dbg("test case Call-ID: %s", string(callIds[i]))
+			_ = WithDebug && Dbg("test case Call-ID: %s", string(callIds[i]))
 			ac := AnonymPField{
 				PField: c.CallID,
 			}
 			l := ac.EncodedLen()
-			Dbg("encoded len: %d", l)
+			_ = WithDebug && Dbg("encoded len: %d", l)
 			encoded := make([]byte, l)
 			if err := ac.Encode(encoded, callIds[i]); err != nil {
 				t.Fatalf("cannot encode Call-ID %s: %s", callIds[i], err.Error())
 			}
-			Dbg("encoded Call-ID: %v (len: %d)", encoded, len(encoded))
-			Dbg("encoded Call-ID: %s", string(ac.PField.Get(encoded)))
+			_ = WithDebug && Dbg("encoded Call-ID: %v (len: %d)", encoded, len(encoded))
+			_ = WithDebug && Dbg("encoded Call-ID: %s", string(ac.PField.Get(encoded)))
 			l = ac.DecodedLen()
 			decoded := make([]byte, l)
 			if err := ac.Decode(decoded, encoded); err != nil {
-				Dbg("decoded Call-ID: %v", decoded)
+				_ = WithDebug && Dbg("decoded Call-ID: %v", decoded)
 				t.Fatalf("cannot decode Call-ID %s: %s", callIds[i], err.Error())
 			}
-			Dbg(`decoded Call-ID: %v "%s"`, ac.PField.Get(decoded), string(ac.PField.Get(decoded)))
+			_ = WithDebug && Dbg(`decoded Call-ID: %v "%s"`, ac.PField.Get(decoded), string(ac.PField.Get(decoded)))
 			if !bytes.Equal(callIds[i], ac.PField.Get(decoded)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, callIds[i], string(ac.PField.Get(decoded)))
 			}
@@ -104,7 +104,7 @@ func TestCallIdCBCEncrypt(t *testing.T) {
 	// tests
 	t.Run("dynamic memory", func(t *testing.T) {
 		for i, c := range pCallIds {
-			Dbg("test case Call-ID: %s", string(callIds[i]))
+			_ = WithDebug && Dbg("test case Call-ID: %s", string(callIds[i]))
 			ac := AnonymPField{
 				PField: c.CallID,
 			}
@@ -112,18 +112,18 @@ func TestCallIdCBCEncrypt(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cannot compute Call-ID pad len %s: %s", callIds[i], err.Error())
 			}
-			Dbg("padded len: %d", l)
+			_ = WithDebug && Dbg("padded len: %d", l)
 			ciphertxt := make([]byte, l)
 			if err := ac.CBCEncrypt(ciphertxt, callIds[i]); err != nil {
 				t.Fatalf("cannot encrypt Call-ID %s: %s", callIds[i], err.Error())
 			}
-			Dbg("encrypted Call-ID: %v (len: %d)", ciphertxt, len(ciphertxt))
+			_ = WithDebug && Dbg("encrypted Call-ID: %v (len: %d)", ciphertxt, len(ciphertxt))
 			plaintxt := make([]byte, len(ciphertxt))
 			if err := ac.CBCDecrypt(plaintxt, ciphertxt); err != nil {
-				Dbg("decrypted Call-ID: %v", plaintxt)
+				_ = WithDebug && Dbg("decrypted Call-ID: %v", plaintxt)
 				t.Fatalf("cannot decrypt Call-ID %s: %s", callIds[i], err.Error())
 			}
-			Dbg("decrypted Call-ID: %v %s", plaintxt, string(ac.PField.Get(plaintxt)))
+			_ = WithDebug && Dbg("decrypted Call-ID: %v %s", plaintxt, string(ac.PField.Get(plaintxt)))
 			if !bytes.Equal(callIds[i], ac.PField.Get(plaintxt)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, callIds[i], string(ac.PField.Get(plaintxt)))
 			}
@@ -170,7 +170,7 @@ func TestCallIdAnonymization(t *testing.T) {
 	// tests
 	t.Run("dynamic memory", func(t *testing.T) {
 		for i, c := range pCallIds {
-			Dbg("test case Call-ID: %s", string(callIds[i]))
+			_ = WithDebug && Dbg("test case Call-ID: %s", string(callIds[i]))
 			ac := AnonymPField{
 				PField: c.CallID,
 			}
@@ -178,13 +178,13 @@ func TestCallIdAnonymization(t *testing.T) {
 			if err := ac.Anonymize(anonym, callIds[i]); err != nil {
 				t.Fatalf("cannot anonymize Call-ID %s: %s", callIds[i], err.Error())
 			}
-			Dbg("anonymized Call-ID: %v %s (len: %d)", ac.PField.Get(anonym), string(ac.PField.Get(anonym)), len(ac.PField.Get(anonym)))
+			_ = WithDebug && Dbg("anonymized Call-ID: %v %s (len: %d)", ac.PField.Get(anonym), string(ac.PField.Get(anonym)), len(ac.PField.Get(anonym)))
 			plaintxt := make([]byte, 2*len(callIds[i])+CallIdCBC().Encrypter.BlockSize())
 			if err := ac.Deanonymize(plaintxt, anonym); err != nil {
-				Dbg("decrypted Call-ID: %v", plaintxt)
+				_ = WithDebug && Dbg("decrypted Call-ID: %v", plaintxt)
 				t.Fatalf("cannot decrypt Call-ID %s: %s", callIds[i], err.Error())
 			}
-			Dbg(`deanonymized Call-ID: %v "%s"`, plaintxt, string(ac.PField.Get(plaintxt)))
+			_ = WithDebug && Dbg(`deanonymized Call-ID: %v "%s"`, plaintxt, string(ac.PField.Get(plaintxt)))
 			if !bytes.Equal(callIds[i], ac.PField.Get(plaintxt)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, callIds[i], string(ac.PField.Get(plaintxt)))
 			}

--- a/debug.go
+++ b/debug.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	Debug string = "off"
+	Debug string = "on"
 
 	stderr *bufio.Writer = nil
 

--- a/debug.go
+++ b/debug.go
@@ -52,7 +52,7 @@ func DbgOff() bool {
 	return prev
 }
 
-func Dbg(format string, args ...interface{}) {
+func Dbg(format string, args ...interface{}) bool {
 	if dbgFlag {
 		if stderr == nil {
 			stderr = bufio.NewWriter(os.Stderr)
@@ -64,11 +64,11 @@ func Dbg(format string, args ...interface{}) {
 		}()
 		n := runtime.Callers(2, callers[:])
 		if n == 0 {
-			return
+			return true
 		}
 		frames := runtime.CallersFrames(callers[:])
 		if frames == nil {
-			return
+			return true
 		}
 		frame, _ := frames.Next()
 		name := frame.Func.Name()
@@ -80,4 +80,5 @@ func Dbg(format string, args ...interface{}) {
 		fln := fmt.Sprintf("%s:%d, %s: ", file, line, name)
 		msg = fln + msg
 	}
+	return true
 }

--- a/encoding.go
+++ b/encoding.go
@@ -22,7 +22,7 @@ func encodeToken(dst, src []byte, pf sipsp.PField, codec *base32.Encoding) (leng
 	df := DbgOn()
 	defer DbgRestore(df)
 	token := pf.Get(src)
-	Dbg("token: %v", token)
+	_ = WithDebug && Dbg("token: %v", token)
 	length = codec.EncodedLen(len(token))
 	ePf := sipsp.PField{
 		Offs: 0,
@@ -41,7 +41,7 @@ func decodeToken(dst, src []byte, pf sipsp.PField, codec *base32.Encoding) (leng
 	length = 0
 	err = nil
 	token := pf.Get(src)
-	Dbg("encoded (src) token: %v", token)
+	_ = WithDebug && Dbg("encoded (src) token: %v", token)
 	length = codec.DecodedLen(len(token))
 	if len(dst) < length {
 		err = fmt.Errorf(`"dst" buffer to small for decoded data (%d bytes required and %d bytes available)`,
@@ -59,6 +59,6 @@ func decodeToken(dst, src []byte, pf sipsp.PField, codec *base32.Encoding) (leng
 		Len:  sipsp.OffsT(length),
 	}
 	dToken = dPf.Get(dst)
-	Dbg("decoded (dst) token: %v len: %d", dToken, len(dToken))
+	_ = WithDebug && Dbg("decoded (dst) token: %v len: %d", dToken, len(dToken))
 	return
 }

--- a/pan-ip.go
+++ b/pan-ip.go
@@ -1,0 +1,156 @@
+// Copyright 2019-2021 Intuitive Labs GmbH. All rights reserved.
+//
+// Use of this source code is governed by a source-available license
+// that can be found in the LICENSE.txt file in the root of the source
+// tree.
+
+// Prefix-preserving IP address anonymization.
+// For details, see the original published research paper here:
+// http://conferences.sigcomm.org/imc/2001/imw2001-papers/69.pdf
+
+package anonymization
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"net"
+)
+
+// Prefix-preserving anonymizer for ip addresses
+// it implements cipher.Block interface
+type PanIPv4 struct {
+	block cipher.Block
+	key   [BlockSize]byte
+	iv    [BlockSize]byte
+	pad   [BlockSize]byte
+}
+
+func NewPanIPv4(key [BlockSize]byte, iv [BlockSize]byte) (pan *PanIPv4, err error) {
+	pan = &PanIPv4{
+		key: key,
+		iv:  iv,
+	}
+	if pan.block, err = aes.NewCipher(key[:]); err != nil {
+		return nil, err
+	}
+	pan.block.Encrypt(pan.pad[:], pan.iv[:])
+	return
+}
+
+func (pan *PanIPv4) BlockSize() int { return BlockSize }
+
+func (pan *PanIPv4) Encrypt(dst, src []byte) {
+	df := DbgOn()
+	defer DbgRestore(df)
+	var (
+		cipher [BlockSize]byte
+		plain  [BlockSize]byte
+
+		result uint32 = 0
+	)
+
+	if len(dst) < net.IPv4len {
+		panic("anonymization/PanIPv4: output's size incorrect")
+	}
+	if len(src) < net.IPv4len {
+		panic("anonymization/PanIPv4: input's size incorrect")
+	}
+	// cco: "IV" is stored in pad
+	copy(plain[:], pan.pad[:])
+
+	// orig_addr starts in network byte order, do all operations in
+	// host byte order
+	orig_addr := binary.BigEndian.Uint32(src[:])
+
+	// cco: "IV" is stored in pad
+	pad32 := binary.LittleEndian.Uint32(pan.pad[0:4])
+	Dbg("pad: %v, pad32: %v", pan.pad[0:4], pad32)
+
+	// For each prefixes with length from 0 to 31, generate a bit
+	// using the given cipher, which is used as a pseudorandom
+	// function here. The bits generated in every rounds are combined
+	// into a pseudorandom one-time-pad.
+	for pos := 0; pos < 32; pos++ {
+
+		mask := uint32(0xffffffff << (32 - pos))
+		// cco: rotate the "IV" bits
+		newpad := (pad32 << pos) | (pad32 >> (32 - pos))
+		if pos == 0 {
+			mask = 0
+			newpad = pad32
+		}
+		Dbg("newpad: %v", newpad)
+
+		// convert plain into network byte order to be encrypted
+		// cco: newpad is a kind of "IV"; it is rotated with 1 bit at each iteration
+		// cco: "IV" bits are XORed with the plain text like in the CBC mode
+		// cco: see also https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_block_chaining_(CBC)
+		//*(u_int32_t*)rin_input = htonl( newpad^(orig_addr&mask));
+		binary.BigEndian.PutUint32(plain[0:4], newpad^(orig_addr&mask))
+
+		// Encryption: The cipher is used as pseudorandom
+		// function. During each round, only the first bit of
+		// cipher is used.
+		pan.block.Encrypt(cipher[:], plain[:])
+
+		// treat cipher, the output of the encryptor as network byte order
+		// Combination: the bits are combined into a pseudorandom one-time-pad
+		//result |= ( (ntohl(*(u_int32_t*)cipher)) & 0x80000000) >> pos;
+		result |= (binary.BigEndian.Uint32(cipher[0:4]) & 0x80000000) >> pos
+		Dbg("result: %v", result)
+	}
+
+	// XOR the orginal address with the pseudorandom one-time-pad
+	// convert result to network byte order before returning
+	//return htonl( result ^ orig_addr );
+	binary.BigEndian.PutUint32(dst, result^orig_addr)
+}
+
+func (pan *PanIPv4) Decrypt(dst, src []byte) {
+	var (
+		cipher [BlockSize]byte
+		plain  [BlockSize]byte
+	)
+
+	if len(dst) < net.IPv4len {
+		panic("anonymization/PanIPv4: output's size incorrect")
+	}
+	if len(src) < net.IPv4len {
+		panic("anonymization/PanIPv4: input's size incorrect")
+	}
+	// cco: "IV" is stored in pad
+	copy(plain[:], pan.pad[:])
+	orig_addr := binary.BigEndian.Uint32(src[:])
+	// cco: "IV" is stored in pad
+	pad32 := binary.LittleEndian.Uint32(pan.pad[0:4])
+	Dbg("pad: %v, pad32: %v", pan.pad[0:4], pad32)
+	for pos := 0; pos < 32; pos++ {
+
+		mask := uint32(0xffffffff << (32 - pos))
+		// cco: rotate the "IV" bits
+		newpad := (pad32 << pos) | (pad32 >> (32 - pos))
+		if pos == 0 {
+			mask = 0
+			newpad = pad32
+		}
+
+		// convert plain into network byte order to be encrypted
+		// cco: newpad is a kind of "IV"; it is rotated with 1 bit at each iteration
+		// cco: "IV" bits are XORed with the plain text like in the CBC mode
+		// cco: see also https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_block_chaining_(CBC)
+		//*(u_int32_t*)rin_input = htonl( newpad^(orig_addr&mask));
+		binary.BigEndian.PutUint32(plain[0:4], newpad^(orig_addr&mask))
+
+		// Encryption: The cipher is used as pseudorandom
+		// function. During each round, only the first bit of
+		// cipher is used.
+		pan.block.Encrypt(cipher[:], plain[:])
+
+		// treat cipher, the output of the encryptor as network byte order
+		// Combination: the bits are combined into a pseudorandom one-time-pad
+		//orig_addr ^= ((ntohl(*(u_int32_t*)rin_output)) & 0x80000000) >> pos;
+		orig_addr ^= (binary.BigEndian.Uint32(cipher[0:4]) & 0x80000000) >> pos
+	}
+	binary.BigEndian.PutUint32(dst, orig_addr)
+}

--- a/pan-ip.go
+++ b/pan-ip.go
@@ -80,7 +80,6 @@ func (pan *PanIPv4) Encrypt(dst, src []byte) {
 			mask = 0
 			newpad = pad32
 		}
-		Dbg("newpad: %v", newpad)
 
 		// convert plain into network byte order to be encrypted
 		// cco: newpad is a kind of "IV"; it is rotated with 1 bit at each iteration
@@ -88,6 +87,8 @@ func (pan *PanIPv4) Encrypt(dst, src []byte) {
 		// cco: see also https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_block_chaining_(CBC)
 		//*(u_int32_t*)rin_input = htonl( newpad^(orig_addr&mask));
 		binary.BigEndian.PutUint32(plain[0:4], newpad^(orig_addr&mask))
+
+		Dbg("newpad: %v, plain: %v", newpad, plain[0:4])
 
 		// Encryption: The cipher is used as pseudorandom
 		// function. During each round, only the first bit of

--- a/pan-ip.go
+++ b/pan-ip.go
@@ -80,12 +80,12 @@ func InitPanIPv4KeysFromMasterKey(masterKey []byte, encKey []byte, iv []byte) {
 	if err := GeneratePanIPIV(masterKey[:], EncryptionKeyLen, iv[:]); err != nil {
 		panic(err)
 	}
-	Dbg("IV: %v", iv[:])
+	_ = WithDebug && Dbg("IV: %v", iv[:])
 	// generate key
 	if err := GeneratePanIPKey(masterKey[:], EncryptionKeyLen, encKey[:]); err != nil {
 		panic(err)
 	}
-	Dbg("Key: %v", encKey[:])
+	_ = WithDebug && Dbg("Key: %v", encKey[:])
 }
 
 func (pan *PanIPv4) WithMasterKey(key []byte) *PanIPv4 {
@@ -149,9 +149,7 @@ func (pan *PanIPv4) Encrypt(dst, src []byte) {
 
 	// cco: "IV" is stored in pad
 	pad := binary.LittleEndian.Uint32(pan.pad[0:4])
-	if WithDebug {
-		Dbg("pad: %v, pad: %v", pan.pad[0:4], pad)
-	}
+	_ = WithDebug && Dbg("pad: %v, pad: %v", pan.pad[0:4], pad)
 
 	// For each prefixes with length from 0 to 31, generate a bit
 	// using the given cipher, which is used as a pseudorandom
@@ -174,9 +172,7 @@ func (pan *PanIPv4) Encrypt(dst, src []byte) {
 		//*(u_int32_t*)rin_input = htonl( newpad^(orig&mask));
 		binary.BigEndian.PutUint32(plain[0:4], newpad^(orig&mask))
 
-		if WithDebug {
-			Dbg("newpad: %v, plain: %v", newpad, plain[0:4])
-		}
+		_ = WithDebug && Dbg("newpad: %v, plain: %v", newpad, plain[0:4])
 
 		// Encryption: The cipher is used as pseudorandom
 		// function. During each round, only the first bit of
@@ -187,9 +183,7 @@ func (pan *PanIPv4) Encrypt(dst, src []byte) {
 		// Combination: the bits are combined into a pseudorandom one-time-pad
 		//result |= ( (ntohl(*(u_int32_t*)cipher)) & 0x80000000) >> pos;
 		result |= (binary.BigEndian.Uint32(cipher[0:4]) & pan.prfMask) >> shift
-		if WithDebug {
-			Dbg("result: %v", result)
-		}
+		_ = WithDebug && Dbg("result: %v", result)
 	}
 
 	// XOR the orginal address with the pseudorandom one-time-pad
@@ -217,9 +211,7 @@ func (pan *PanIPv4) Decrypt(dst, src []byte) {
 	orig := binary.BigEndian.Uint32(src[:])
 	// cco: "IV" is stored in pad
 	pad := binary.LittleEndian.Uint32(pan.pad[0:4])
-	if WithDebug {
-		Dbg("pad: %v, pad: %v", pan.pad[0:4], pad)
-	}
+	_ = WithDebug && Dbg("pad: %v, pad: %v", pan.pad[0:4], pad)
 	for pos := BitPrefixLen(0); pos < BitPrefixLen(32)/pan.prefixFactor; pos++ {
 		shift := uint32(pan.prefixFactor * pos)
 		mask := uint32(0xffffffff << (32 - shift))
@@ -246,9 +238,7 @@ func (pan *PanIPv4) Decrypt(dst, src []byte) {
 		// Combination: the bits are combined into a pseudorandom one-time-pad
 		//orig ^= ((ntohl(*(u_int32_t*)rin_output)) & 0x80000000) >> pos;
 		orig ^= (binary.BigEndian.Uint32(cipher[0:4]) & pan.prfMask) >> shift
-		if WithDebug {
-			Dbg("newpad: %v, plain: %v, cipher: %v, orig: %v", newpad, plain, cipher, orig)
-		}
+		_ = WithDebug && Dbg("newpad: %v, plain: %v, cipher: %v, orig: %v", newpad, plain, cipher, orig)
 	}
 	binary.BigEndian.PutUint32(dst, orig)
 }

--- a/pan-ip.go
+++ b/pan-ip.go
@@ -37,7 +37,7 @@ var (
 	pan4 PanIPv4
 )
 
-func NewPanIPv4(masterKey [BlockSize]byte) (pan *PanIPv4) {
+func NewPanIPv4(masterKey []byte) (pan *PanIPv4) {
 	pan = GetPan4()
 	pan.WithMasterKey(masterKey)
 	return
@@ -70,7 +70,7 @@ func InitPanIPv4KeysFromMasterKey(masterKey []byte, encKey []byte, iv []byte) {
 	Dbg("Key: %v", encKey[:])
 }
 
-func (pan *PanIPv4) WithMasterKey(key [BlockSize]byte) *PanIPv4 {
+func (pan *PanIPv4) WithMasterKey(key []byte) *PanIPv4 {
 	var err error
 	InitPanIPv4KeysFromMasterKey(key[:], pan.Key[:], pan.IV[:])
 	if pan.block, err = aes.NewCipher(pan.Key[:]); err != nil {

--- a/pan-ip_test.go
+++ b/pan-ip_test.go
@@ -10,10 +10,7 @@ func TestPanIP(t *testing.T) {
 	// set-up if needed
 	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
 	iv := [16]byte{216, 152, 143, 131, 121, 121, 101, 39, 98, 87, 76, 45, 42, 132, 34, 2}
-	pan, err := NewPanIPv4(key, iv)
-	if err != nil {
-		t.Fatalf("prefix-preserving IP address anonymizer initialization error")
-	}
+	pan := GetPan4().WithKeyAndIV(key, iv)
 	t.Run("IPv4", func(t *testing.T) {
 		cases := []net.IP{
 			[]byte{24, 5, 0, 80},
@@ -42,10 +39,7 @@ func BenchmarkPanIP(b *testing.B) {
 	defer DbgRestore(df)
 	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
 	iv := [16]byte{216, 152, 143, 131, 121, 121, 101, 39, 98, 87, 76, 45, 42, 132, 34, 2}
-	pan, err := NewPanIPv4(key, iv)
-	if err != nil {
-		b.Fatalf("prefix-preserving IP address anonymizer initialization error")
-	}
+	pan := GetPan4().WithKeyAndIV(key, iv)
 	b.Run("IPv4", func(b *testing.B) {
 		cases := []net.IP{
 			[]byte{24, 5, 0, 80},

--- a/pan-ip_test.go
+++ b/pan-ip_test.go
@@ -47,6 +47,7 @@ func TestPanIPv4(t *testing.T) {
 			[]byte{1, 5, 6, 7},
 			[]byte{1, 2, 8, 9},
 			[]byte{1, 2, 3, 10},
+			[]byte{85, 2, 3, 10},
 		}
 		pan := GetPan4().WithMasterKey(encKey[:]).WithBitsPrefixBoundary(EightBitsPrefix)
 		enc = make([]byte, net.IPv4len)

--- a/pan-ip_test.go
+++ b/pan-ip_test.go
@@ -1,0 +1,65 @@
+package anonymization
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func TestPanIP(t *testing.T) {
+	// set-up if needed
+	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
+	iv := [16]byte{216, 152, 143, 131, 121, 121, 101, 39, 98, 87, 76, 45, 42, 132, 34, 2}
+	pan, err := NewPanIPv4(key, iv)
+	if err != nil {
+		t.Fatalf("prefix-preserving IP address anonymizer initialization error")
+	}
+	t.Run("IPv4", func(t *testing.T) {
+		cases := []net.IP{
+			[]byte{24, 5, 0, 80},
+			[]byte{24, 5, 56, 22},
+			[]byte{22, 11, 33, 44},
+			[]byte{255, 0, 255, 241},
+		}
+		var enc, dec net.IP
+		enc = make([]byte, net.IPv4len)
+		dec = make([]byte, net.IPv4len)
+		for _, c := range cases {
+			pan.Encrypt(enc, c)
+			t.Logf("plain: %s encrypted: %s", c.String(), enc.String())
+			pan.Decrypt(dec, enc)
+			t.Logf("encrypted: %s decrypted: %s", enc.String(), dec.String())
+			if !bytes.Equal(dec, c) {
+				t.Errorf("expected: %s have: %s (enc: %s)", c.String(), dec.String(), enc.String())
+			}
+		}
+	})
+}
+
+func BenchmarkPanIP(b *testing.B) {
+	// set-up if needed
+	df := DbgOff()
+	defer DbgRestore(df)
+	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
+	iv := [16]byte{216, 152, 143, 131, 121, 121, 101, 39, 98, 87, 76, 45, 42, 132, 34, 2}
+	pan, err := NewPanIPv4(key, iv)
+	if err != nil {
+		b.Fatalf("prefix-preserving IP address anonymizer initialization error")
+	}
+	b.Run("IPv4", func(b *testing.B) {
+		cases := []net.IP{
+			[]byte{24, 5, 0, 80},
+			//[]byte{24, 5, 56, 22},
+			//[]byte{22, 11, 33, 44},
+			//[]byte{255, 0, 255, 241},
+		}
+		var enc net.IP
+		enc = make([]byte, net.IPv4len)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, c := range cases {
+				pan.Encrypt(enc, c)
+			}
+		}
+	})
+}

--- a/pan-ip_test.go
+++ b/pan-ip_test.go
@@ -10,13 +10,16 @@ func TestPanIP(t *testing.T) {
 	// set-up if needed
 	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
 	iv := [16]byte{216, 152, 143, 131, 121, 121, 101, 39, 98, 87, 76, 45, 42, 132, 34, 2}
-	pan := GetPan4().WithKeyAndIV(key, iv)
+	pan := GetPan4().WithKeyAndIV(key, iv).WithBitsPrefixBoundary(EightBitsPrefix)
 	t.Run("IPv4", func(t *testing.T) {
 		cases := []net.IP{
 			[]byte{24, 5, 0, 80},
-			[]byte{24, 5, 56, 22},
 			[]byte{22, 11, 33, 44},
 			[]byte{255, 0, 255, 241},
+			[]byte{1, 2, 3, 4},
+			[]byte{1, 5, 6, 7},
+			[]byte{1, 2, 8, 9},
+			[]byte{1, 2, 3, 10},
 		}
 		var enc, dec net.IP
 		enc = make([]byte, net.IPv4len)
@@ -40,7 +43,24 @@ func BenchmarkPanIP(b *testing.B) {
 	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
 	iv := [16]byte{216, 152, 143, 131, 121, 121, 101, 39, 98, 87, 76, 45, 42, 132, 34, 2}
 	pan := GetPan4().WithKeyAndIV(key, iv)
-	b.Run("IPv4", func(b *testing.B) {
+	b.Run("IPv4 1 bit boundary", func(b *testing.B) {
+		cases := []net.IP{
+			[]byte{24, 5, 0, 80},
+			//[]byte{24, 5, 56, 22},
+			//[]byte{22, 11, 33, 44},
+			//[]byte{255, 0, 255, 241},
+		}
+		pan = GetPan4().WithBitsPrefixBoundary(OneBitPrefix)
+		var enc net.IP
+		enc = make([]byte, net.IPv4len)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, c := range cases {
+				pan.Encrypt(enc, c)
+			}
+		}
+	})
+	b.Run("IPv4 2 bits boundary", func(b *testing.B) {
 		cases := []net.IP{
 			[]byte{24, 5, 0, 80},
 			//[]byte{24, 5, 56, 22},
@@ -48,6 +68,41 @@ func BenchmarkPanIP(b *testing.B) {
 			//[]byte{255, 0, 255, 241},
 		}
 		var enc net.IP
+		pan = GetPan4().WithBitsPrefixBoundary(TwoBitsPrefix)
+		enc = make([]byte, net.IPv4len)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, c := range cases {
+				pan.Encrypt(enc, c)
+			}
+		}
+	})
+	b.Run("IPv4 4 bits boundary", func(b *testing.B) {
+		cases := []net.IP{
+			[]byte{24, 5, 0, 80},
+			//[]byte{24, 5, 56, 22},
+			//[]byte{22, 11, 33, 44},
+			//[]byte{255, 0, 255, 241},
+		}
+		var enc net.IP
+		pan = GetPan4().WithBitsPrefixBoundary(FourBitsPrefix)
+		enc = make([]byte, net.IPv4len)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for _, c := range cases {
+				pan.Encrypt(enc, c)
+			}
+		}
+	})
+	b.Run("IPv4 8 bits boundary", func(b *testing.B) {
+		cases := []net.IP{
+			[]byte{24, 5, 0, 80},
+			//[]byte{24, 5, 56, 22},
+			//[]byte{22, 11, 33, 44},
+			//[]byte{255, 0, 255, 241},
+		}
+		var enc net.IP
+		pan = GetPan4().WithBitsPrefixBoundary(EightBitsPrefix)
 		enc = make([]byte, net.IPv4len)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/pan-ip_test.go
+++ b/pan-ip_test.go
@@ -6,12 +6,15 @@ import (
 	"testing"
 )
 
-func TestPanIP(t *testing.T) {
+func TestPanIPv4(t *testing.T) {
 	// set-up if needed
 	key := [16]byte{21, 34, 23, 141, 51, 164, 207, 128, 19, 10, 91, 22, 73, 144, 125, 16}
 	iv := [16]byte{216, 152, 143, 131, 121, 121, 101, 39, 98, 87, 76, 45, 42, 132, 34, 2}
-	pan := GetPan4().WithKeyAndIV(key, iv).WithBitsPrefixBoundary(EightBitsPrefix)
-	t.Run("IPv4", func(t *testing.T) {
+	var encKey [EncryptionKeyLen]byte
+	pass := "foobar"
+	GenerateKeyFromPassphraseAndCopy(pass, EncryptionKeyLen, encKey[:])
+	t.Run("random keys", func(t *testing.T) {
+		var enc, dec net.IP
 		cases := []net.IP{
 			[]byte{24, 5, 0, 80},
 			[]byte{22, 11, 33, 44},
@@ -21,7 +24,31 @@ func TestPanIP(t *testing.T) {
 			[]byte{1, 2, 8, 9},
 			[]byte{1, 2, 3, 10},
 		}
+		pan := GetPan4().WithKeyAndIV(key, iv).WithBitsPrefixBoundary(EightBitsPrefix)
+		enc = make([]byte, net.IPv4len)
+		dec = make([]byte, net.IPv4len)
+		for _, c := range cases {
+			pan.Encrypt(enc, c)
+			t.Logf("plain: %s encrypted: %s", c.String(), enc.String())
+			pan.Decrypt(dec, enc)
+			t.Logf("encrypted: %s decrypted: %s", enc.String(), dec.String())
+			if !bytes.Equal(dec, c) {
+				t.Errorf("expected: %s have: %s (enc: %s)", c.String(), dec.String(), enc.String())
+			}
+		}
+	})
+	t.Run("password keys", func(t *testing.T) {
 		var enc, dec net.IP
+		cases := []net.IP{
+			[]byte{24, 5, 0, 80},
+			[]byte{22, 11, 33, 44},
+			[]byte{255, 0, 255, 241},
+			[]byte{1, 2, 3, 4},
+			[]byte{1, 5, 6, 7},
+			[]byte{1, 2, 8, 9},
+			[]byte{1, 2, 3, 10},
+		}
+		pan := GetPan4().WithMasterKey(encKey[:]).WithBitsPrefixBoundary(EightBitsPrefix)
 		enc = make([]byte, net.IPv4len)
 		dec = make([]byte, net.IPv4len)
 		for _, c := range cases {

--- a/passphrase_test.go
+++ b/passphrase_test.go
@@ -42,7 +42,7 @@ func TestKeyValidationCode(t *testing.T) {
 					if c := validator.Compute(); len(c) == 0 {
 						t.Errorf("validator code len is 0")
 					} else {
-						Dbg("key validation code: %s", c)
+						_ = WithDebug && Dbg("key validation code: %s", c)
 					}
 				}
 				// this thread is ready
@@ -65,7 +65,7 @@ func TestKeyValidationCode(t *testing.T) {
 					if c := validator.Compute(); len(c) == 0 {
 						t.Errorf("validator code len is 0")
 					} else {
-						Dbg("key validation code: %s", c)
+						_ = WithDebug && Dbg("key validation code: %s", c)
 						if !validator.Validate(c) {
 							t.Errorf("key is not valid")
 						}
@@ -91,7 +91,7 @@ func TestKeyValidationCode(t *testing.T) {
 					if c := validator.Compute(); len(c) == 0 {
 						t.Errorf("validator code len is 0")
 					} else {
-						Dbg("key validation code: %s", c)
+						_ = WithDebug && Dbg("key validation code: %s", c)
 						if !validator.Validate(c) {
 							t.Errorf("key is not valid")
 						}
@@ -115,7 +115,7 @@ func TestKeyValidationCode(t *testing.T) {
 					if c := validator.Compute(); len(c) == 0 {
 						t.Errorf("validator code len is 0")
 					} else {
-						Dbg("key validation code: %s", c)
+						_ = WithDebug && Dbg("key validation code: %s", c)
 						if !validator.Validate(c) {
 							t.Errorf("key is not valid")
 						}
@@ -137,7 +137,7 @@ func TestKeyValidationCode(t *testing.T) {
 				if c := validator.Compute(); len(c) == 0 {
 					t.Errorf("validator code len is 0")
 				} else {
-					Dbg("key validation code: %s", c)
+					_ = WithDebug && Dbg("key validation code: %s", c)
 					if !validator.Validate(c) {
 						t.Errorf("key is not valid")
 					}
@@ -147,7 +147,7 @@ func TestKeyValidationCode(t *testing.T) {
 	})
 	t.Run("auth key from passphrase no nonce", func(t *testing.T) {
 		k := GenerateKeyFromPassphrase(passphrases[0], AuthenticationKeyLen)
-		Dbg("authentication key: %v", k)
+		_ = WithDebug && Dbg("authentication key: %v", k)
 		for l := 0; l <= crypto.SHA256.Size(); l++ {
 			if validator, err := NewKeyValidator(crypto.SHA256, k, l, "salt", NonceNone, false); err != nil {
 				t.Fatalf("validator initialization error %s", err)
@@ -155,7 +155,7 @@ func TestKeyValidationCode(t *testing.T) {
 				if c := validator.Compute(); len(c) == 0 {
 					t.Errorf("validator code len is 0")
 				} else {
-					Dbg("key validation code: %s", c)
+					_ = WithDebug && Dbg("key validation code: %s", c)
 					if !validator.Validate(c) {
 						t.Errorf("key is not valid")
 					}
@@ -165,7 +165,7 @@ func TestKeyValidationCode(t *testing.T) {
 	})
 	t.Run("auth key from passphrase no nonce, salt a86483ec-8568-48da-b2cc-b4db9307d7f4", func(t *testing.T) {
 		k := GenerateKeyFromPassphrase(passphrases[0], AuthenticationKeyLen)
-		Dbg("authentication key: %v", k)
+		_ = WithDebug && Dbg("authentication key: %v", k)
 		for l := 0; l <= crypto.SHA256.Size(); l++ {
 			if validator, err := NewKeyValidator(crypto.SHA256, k, l, "a86483ec-8568-48da-b2cc-b4db9307d7f4", NonceNone, false); err != nil {
 				t.Fatalf("validator initialization error %s", err)
@@ -173,7 +173,7 @@ func TestKeyValidationCode(t *testing.T) {
 				if c := validator.Compute(); len(c) == 0 {
 					t.Errorf("validator code len is 0")
 				} else {
-					Dbg("key validation code: %s", c)
+					_ = WithDebug && Dbg("key validation code: %s", c)
 					if !validator.Validate(c) {
 						t.Errorf("key is not valid")
 					}
@@ -183,12 +183,12 @@ func TestKeyValidationCode(t *testing.T) {
 	})
 	t.Run("auth key from passphrase no nonce, no salt validate remote code", func(t *testing.T) {
 		k := GenerateKeyFromPassphrase(passphrases[0], AuthenticationKeyLen)
-		Dbg("authentication key: %v", k)
+		_ = WithDebug && Dbg("authentication key: %v", k)
 		if validator, err := NewKeyValidator(crypto.SHA256, k, 5, "", NonceNone, false); err != nil {
 			t.Fatalf("validator initialization error %s", err)
 		} else {
 			c := "5c9b4:a86483ec-8568-48da-b2cc-b4db9307d7f4"
-			Dbg("key validation code: %s", c)
+			_ = WithDebug && Dbg("key validation code: %s", c)
 			if !validator.Validate(c) {
 				t.Errorf("key is not valid")
 			}
@@ -196,9 +196,9 @@ func TestKeyValidationCode(t *testing.T) {
 	})
 	t.Run("auth key from encryption key no nonce", func(t *testing.T) {
 		encKey := GenerateKeyFromPassphrase(passphrases[0], EncryptionKeyLen)
-		Dbg("encryption key: %v", encKey)
+		_ = WithDebug && Dbg("encryption key: %v", encKey)
 		authKey := GenerateKeyFromBytes(encKey[:], AuthenticationKeyLen)
-		Dbg("authentication key: %v", authKey)
+		_ = WithDebug && Dbg("authentication key: %v", authKey)
 		for l := 0; l <= crypto.SHA256.Size(); l++ {
 			if validator, err := NewKeyValidator(crypto.SHA256, authKey, l, "salt", NonceNone, false); err != nil {
 				t.Fatalf("validator initialization error %s", err)
@@ -206,7 +206,7 @@ func TestKeyValidationCode(t *testing.T) {
 				if c := validator.Compute(); len(c) == 0 {
 					t.Errorf("validator code len is 0")
 				} else {
-					Dbg("key validation code: %s", c)
+					_ = WithDebug && Dbg("key validation code: %s", c)
 					if !validator.Validate(c) {
 						t.Errorf("key is not valid")
 					}

--- a/pkcs_test.go
+++ b/pkcs_test.go
@@ -161,7 +161,7 @@ func TestPKCSPad(t *testing.T) {
 		df := DbgOff()
 		defer DbgRestore(df)
 		for i, pair := range oneBlockPairs {
-			Dbg("i: %d, padded: %v", i, pair.padded)
+			_ = WithDebug && Dbg("i: %d, padded: %v", i, pair.padded)
 			if u, err := PKCSUnpad(pair.padded, 16); err != nil {
 				t.Fatalf("unpadding error: %s", err)
 			} else if !bytes.Equal(u, pair.unpadded[:16-1-i]) {
@@ -173,7 +173,7 @@ func TestPKCSPad(t *testing.T) {
 		df := DbgOff()
 		defer DbgRestore(df)
 		for i, pair := range oneBlockPairs {
-			Dbg("i: %d, padded: %v", i, pair.padded)
+			_ = WithDebug && Dbg("i: %d, padded: %v", i, pair.padded)
 			if p, err := PKCSPad(pair.unpadded, 0, len(pair.unpadded)-1-i, 16); err != nil {
 				t.Fatalf("padding error: %s", err)
 			} else if !bytes.Equal(p[0:16], pair.padded) {
@@ -224,7 +224,7 @@ func TestPKCSPad(t *testing.T) {
 		df := DbgOff()
 		defer DbgRestore(df)
 		for i, pair := range manyBlockPairs {
-			Dbg("i: %d, padded: %v", i, pair.padded)
+			_ = WithDebug && Dbg("i: %d, padded: %v", i, pair.padded)
 			u, err := PKCSUnpad(pair.padded, 16)
 			if err != nil {
 				t.Fatalf("unpadding error: %s", err)
@@ -238,7 +238,7 @@ func TestPKCSPad(t *testing.T) {
 	})
 	t.Run("broken padding", func(t *testing.T) {
 		for _, b := range broken {
-			Dbg("block: %v", b)
+			_ = WithDebug && Dbg("block: %v", b)
 			if _, err := PKCSUnpad(b, 16); err == nil {
 				t.Fatalf("expecting error while unpadding %v", b)
 			}

--- a/uri.go
+++ b/uri.go
@@ -142,7 +142,7 @@ func (uri *AnonymURI) copyPortParamsHeaders(dst, src []byte) sipsp.OffsT {
 	if pph == nil {
 		return 0
 	}
-	Dbg("pph: %v %s", pph, string(pph))
+	_ = WithDebug && Dbg("pph: %v %s", pph, string(pph))
 	offs := int(uri.Host.Offs + uri.Host.Len)
 	if uri.Port.Offs > 0 && uri.Port.Len > 0 {
 		// write ':' into dst
@@ -156,10 +156,10 @@ func (uri *AnonymURI) copyPortParamsHeaders(dst, src []byte) sipsp.OffsT {
 	}
 	offs++
 	_ = copy(dst[offs:], pph)
-	Dbg("offs: %d dst[offs:]: %v", offs, dst[offs:])
+	_ = WithDebug && Dbg("offs: %d dst[offs:]: %v", offs, dst[offs:])
 	if uri.Port.Offs > 0 {
 		uri.Port.Offs = sipsp.OffsT(offs)
-		Dbg("uri.Port.Offs: %d", offs)
+		_ = WithDebug && Dbg("uri.Port.Offs: %d", offs)
 		offs += int(uri.Port.Len)
 	}
 	if uri.Params.Offs > 0 {
@@ -168,7 +168,7 @@ func (uri *AnonymURI) copyPortParamsHeaders(dst, src []byte) sipsp.OffsT {
 			offs++
 		}
 		uri.Params.Offs = sipsp.OffsT(offs)
-		Dbg("uri.Param.Offs: %d", offs)
+		_ = WithDebug && Dbg("uri.Param.Offs: %d", offs)
 		offs += int(uri.Params.Len)
 	}
 	if uri.Headers.Offs > 0 {
@@ -177,7 +177,7 @@ func (uri *AnonymURI) copyPortParamsHeaders(dst, src []byte) sipsp.OffsT {
 			offs++
 		}
 		uri.Headers.Offs = sipsp.OffsT(offs)
-		Dbg("uri.Headers.Offs: %d", offs)
+		_ = WithDebug && Dbg("uri.Headers.Offs: %d", offs)
 		offs += int(uri.Headers.Len)
 	}
 	return 1 + uri.Port.Len + uri.Params.Len + uri.Headers.Len
@@ -223,16 +223,16 @@ func (uri AnonymURI) portParamsHeadersEnd() sipsp.OffsT {
 	defer DbgRestore(df)
 	end := uri.Headers.Offs + uri.Headers.Len
 	if end != 0 {
-		Dbg("pph.end: %d, uri.Headers.Offs: %d", end, uri.Headers.Offs)
+		_ = WithDebug && Dbg("pph.end: %d, uri.Headers.Offs: %d", end, uri.Headers.Offs)
 		return end
 	}
 	end = uri.Params.Offs + uri.Params.Len
 	if end != 0 {
-		Dbg("pph end: %d, uri.Params.Offs: %d", end, uri.Params.Offs)
+		_ = WithDebug && Dbg("pph end: %d, uri.Params.Offs: %d", end, uri.Params.Offs)
 		return end
 	}
 	end = uri.Port.Offs + uri.Port.Len
-	Dbg("pph end: %d, uri.Port.Offs: %d", end, uri.Port.Offs)
+	_ = WithDebug && Dbg("pph end: %d, uri.Port.Offs: %d", end, uri.Port.Offs)
 	return end
 }
 
@@ -241,16 +241,16 @@ func (uri AnonymURI) portParamsHeadersStart() sipsp.OffsT {
 	defer DbgRestore(df)
 	start := uri.Port.Offs
 	if start != 0 {
-		Dbg("pph start: uri.Port.Offs: %d", start)
+		_ = WithDebug && Dbg("pph start: uri.Port.Offs: %d", start)
 		return start
 	}
 	start = uri.Params.Offs
 	if start != 0 {
-		Dbg("pph start: uri.Params.Offs: %d", start)
+		_ = WithDebug && Dbg("pph start: uri.Params.Offs: %d", start)
 		return start
 	}
 	start = uri.Headers.Offs
-	Dbg("pph start: uri.Headers.Offs: %d", start)
+	_ = WithDebug && Dbg("pph start: uri.Headers.Offs: %d", start)
 	return start
 }
 
@@ -356,7 +356,7 @@ func (uri *AnonymURI) CBCEncrypt(dst, src []byte, opts ...bool) (err error) {
 	}
 	// 2. copy sip scheme
 	offs = int(uri.copyScheme(dst, src))
-	Dbg(`dst: "%s"`, string(dst[0:uri.Scheme.Len]))
+	_ = WithDebug && Dbg(`dst: "%s"`, string(dst[0:uri.Scheme.Len]))
 	// 3. copy, pad & encrypt user+pass
 	l, err := uri.cbcEncryptUserInfo(dst, src, offs)
 	if err != nil {
@@ -373,7 +373,7 @@ func (uri *AnonymURI) CBCEncrypt(dst, src []byte, opts ...bool) (err error) {
 	if err != nil {
 		return fmt.Errorf("cannot encrypt URI: %w", err)
 	}
-	Dbg("dst: %v", dst)
+	_ = WithDebug && Dbg("dst: %v", dst)
 	return nil
 }
 
@@ -399,14 +399,14 @@ func (uri *AnonymURI) CBCDecrypt(dst, src []byte) (err error) {
 			Len:  uri.User.Len,
 		}
 		user := pf.Get(src)
-		Dbg("encrypted user part: %v", user)
+		_ = WithDebug && Dbg("encrypted user part: %v", user)
 		UriCBC().User.Reset()
 		UriCBC().User.Decrypter.CryptBlocks(dUser, user)
-		Dbg("decrypted user part (padded): %v", dUser)
+		_ = WithDebug && Dbg("decrypted user part (padded): %v", dUser)
 		if user, err = PKCSUnpad(dUser, blockSize); err != nil {
 			return fmt.Errorf("cannot decrypt URI's user part: %w", err)
 		}
-		Dbg("decrypted user part (un-padded): %v %s", user, string(user))
+		_ = WithDebug && Dbg("decrypted user part (un-padded): %v %s", user, string(user))
 		l := len(user)
 		uri.User.Offs = sipsp.OffsT(offs)
 		uri.User.Len = sipsp.OffsT(l)
@@ -414,7 +414,7 @@ func (uri *AnonymURI) CBCDecrypt(dst, src []byte) (err error) {
 		offs = int(uri.User.Offs + uri.User.Len)
 		dst[offs] = '@'
 		offs++
-		Dbg("len(dst[offs:]): %d", len(dst[offs:]))
+		_ = WithDebug && Dbg("len(dst[offs:]): %d", len(dst[offs:]))
 	}
 	dPf := sipsp.PField{
 		Offs: sipsp.OffsT(offs),
@@ -426,15 +426,15 @@ func (uri *AnonymURI) CBCDecrypt(dst, src []byte) (err error) {
 		Len:  uri.Host.Len,
 	}
 	host := pf.Get(src)
-	Dbg("host offs: %d host len : %d", int(uri.Host.Offs), int(uri.Host.Len))
+	_ = WithDebug && Dbg("host offs: %d host len : %d", int(uri.Host.Offs), int(uri.Host.Len))
 	UriCBC().Host.Reset()
 	UriCBC().Host.Decrypter.CryptBlocks(dHost, host)
-	Dbg("decrypted host part (padded): %v", dHost)
+	_ = WithDebug && Dbg("decrypted host part (padded): %v", dHost)
 	uri.Host.Offs = sipsp.OffsT(offs)
 	if host, err = PKCSUnpad(dHost, blockSize); err != nil {
 		return fmt.Errorf("cannot decrypt URI's host part: %w", err)
 	}
-	Dbg("decrypted host part (un-padded): %v %s", host, string(host))
+	_ = WithDebug && Dbg("decrypted host part (un-padded): %v %s", host, string(host))
 	uri.Host.Len = sipsp.OffsT(len(host))
 	_ = uri.copyPortParamsHeaders(dst, src)
 	return nil
@@ -516,7 +516,7 @@ func (uri *AnonymURI) Encode(dst, src []byte, opts ...bool) (err error) {
 		uri.User.Len = sipsp.OffsT(l)
 		// `password` was encoded as part of `user`
 		uri.Pass.Offs, uri.Pass.Len = 0, 0
-		Dbg("encoded user: %v", uri.User.Get(dst))
+		_ = WithDebug && Dbg("encoded user: %v", uri.User.Get(dst))
 		offs = int(uri.User.Offs + uri.User.Len)
 		// write '@' into dst
 		dst[offs] = '@'
@@ -535,7 +535,7 @@ func (uri *AnonymURI) Encode(dst, src []byte, opts ...bool) (err error) {
 		// update the Offs and Len of the Host
 		uri.Host.Offs = sipsp.OffsT(offs)
 		uri.Host.Len = sipsp.OffsT(l)
-		Dbg("encoded host: %v", uri.Host.Get(dst))
+		_ = WithDebug && Dbg("encoded host: %v", uri.Host.Get(dst))
 		offs += int(uri.Host.Len)
 	}
 	if onlyHost {
@@ -570,7 +570,7 @@ func (uri *AnonymURI) Decode(dst, src []byte) (err error) {
 		pf := sipsp.PField{}
 		pf.Set(int(uri.User.Offs), int(userEnd))
 		user := pf.Get(src)
-		Dbg("user: %v %s", user, string(user))
+		_ = WithDebug && Dbg("user: %v %s", user, string(user))
 		ePf := sipsp.PField{
 			Offs: uri.User.Offs,
 			Len:  sipsp.OffsT(codec.DecodedLen(len(user))),
@@ -582,7 +582,7 @@ func (uri *AnonymURI) Decode(dst, src []byte) (err error) {
 		}
 		uri.User.Len = sipsp.OffsT(n)
 		uri.Pass.Offs, uri.Pass.Len = 0, 0
-		Dbg("decoded eUser: %v", eUser[:n])
+		_ = WithDebug && Dbg("decoded eUser: %v", eUser[:n])
 		offs = int(uri.User.Offs + uri.User.Len)
 		// write '@' into dst
 		dst[offs] = '@'
@@ -599,7 +599,7 @@ func (uri *AnonymURI) Decode(dst, src []byte) (err error) {
 	if err != nil {
 		return fmt.Errorf("error decoding URI host part: %w", err)
 	}
-	Dbg("decoded host: %v", dHost[:l])
+	_ = WithDebug && Dbg("decoded host: %v", dHost[:l])
 	uri.Host.Offs = sipsp.OffsT(offs)
 	uri.Host.Len = sipsp.OffsT(l)
 	_ = uri.copyPortParamsHeaders(dst, src)

--- a/uri.go
+++ b/uri.go
@@ -78,7 +78,7 @@ func InitUriKeys(iv []byte, uk []byte, hk []byte) {
 	copy(GetUriKeys().HostKey[:], hk)
 }
 
-func InitUriKeysFromMasterKey(masterKey []byte, keyLen int) {
+func InitUriKeysFromMasterKey(masterKey []byte) {
 	// generate IV for CBC
 	GenerateUriIV(masterKey[:], EncryptionKeyLen, GetUriKeys().IV[:])
 	// generate key for URI's user part

--- a/uri_test.go
+++ b/uri_test.go
@@ -75,24 +75,23 @@ func TestUriBase32Codec(t *testing.T) {
 	// tests
 	t.Run("dynamic memory", func(t *testing.T) {
 		for i, u := range pUris {
-			Dbg("test case uri: %s", string(uris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
 			au := AnonymURI(u)
 			l := au.EncodedLen(uris[i])
-			Dbg("encoded len: %d", l)
+			_ = WithDebug && Dbg("encoded len: %d", l)
 			encoded := make([]byte, l)
 			if err := au.Encode(encoded, uris[i]); err != nil {
 				t.Fatalf("cannot encode URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("encoded URI: %v (len: %d)", encoded, len(encoded))
-			//Dbg("encoded URI: %s", au.Str*ing(encoded))
-			Dbg("encoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(encoded)))
+			_ = WithDebug && Dbg("encoded URI: %v (len: %d)", encoded, len(encoded))
+			_ = WithDebug && Dbg("encoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(encoded)))
 			l = au.DecodedLen(encoded)
 			decoded := make([]byte, l)
 			if err := au.Decode(decoded, encoded); err != nil {
-				Dbg("decoded URI: %v", decoded)
+				_ = WithDebug && Dbg("decoded URI: %v", decoded)
 				t.Fatalf("cannot decode URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("decoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(decoded)))
+			_ = WithDebug && Dbg("decoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(decoded)))
 			uri := sipsp.PsipURI(au)
 			if !bytes.Equal(uris[i], uri.Flat(decoded)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, uris[i], string(uri.Flat(decoded)))
@@ -101,24 +100,23 @@ func TestUriBase32Codec(t *testing.T) {
 	})
 	t.Run("host only", func(t *testing.T) {
 		for i, u := range pUris {
-			Dbg("test case uri: %s", string(uris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
 			au := AnonymURI(u)
 			l := au.EncodedLen(uris[i])
-			Dbg("encoded len: %d", l)
+			_ = WithDebug && Dbg("encoded len: %d", l)
 			encoded := make([]byte, l)
 			if err := au.Encode(encoded, uris[i], true); err != nil {
 				t.Fatalf("cannot encode URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("encoded URI: %v (len: %d)", encoded, len(encoded))
-			//Dbg("encoded URI: %s", au.Str*ing(encoded))
-			Dbg("encoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(encoded)))
+			_ = WithDebug && Dbg("encoded URI: %v (len: %d)", encoded, len(encoded))
+			_ = WithDebug && Dbg("encoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(encoded)))
 			l = au.DecodedLen(encoded)
 			decoded := make([]byte, l)
 			if err := au.Decode(decoded, encoded); err != nil {
-				Dbg("decoded URI: %v", decoded)
+				_ = WithDebug && Dbg("decoded URI: %v", decoded)
 				t.Fatalf("cannot decode URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("decoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(decoded)))
+			_ = WithDebug && Dbg("decoded URI: %s", string((*sipsp.PsipURI)(&au).Flat(decoded)))
 			uri := sipsp.PsipURI(au)
 			if !bytes.Equal(uris[i], uri.Flat(decoded)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, uris[i], string(uri.Flat(decoded)))
@@ -178,24 +176,24 @@ func TestUriCBCEncrypt(t *testing.T) {
 	// tests
 	t.Run("dynamic memory", func(t *testing.T) {
 		for i, u := range pUris {
-			Dbg("test case uri: %s", string(uris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
 			au := AnonymURI(u)
 			l, err := au.PKCSPaddedLen(cipher.User.Encrypter.BlockSize())
 			if err != nil {
 				t.Fatalf("cannot compute URI pad len %s: %s", uris[i], err.Error())
 			}
-			Dbg("padded len: %d", l)
+			_ = WithDebug && Dbg("padded len: %d", l)
 			ciphertxt := make([]byte, l)
 			if err := au.CBCEncrypt(ciphertxt, uris[i]); err != nil {
 				t.Fatalf("cannot encrypt URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("encrypted URI: %v (len: %d)", ciphertxt, len(ciphertxt))
+			_ = WithDebug && Dbg("encrypted URI: %v (len: %d)", ciphertxt, len(ciphertxt))
 			plaintxt := make([]byte, len(ciphertxt))
 			if err := au.CBCDecrypt(plaintxt, ciphertxt); err != nil {
-				Dbg("decrypted URI: %v", plaintxt)
+				_ = WithDebug && Dbg("decrypted URI: %v", plaintxt)
 				t.Fatalf("cannot decrypt URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("decrypted URI: %v %s", plaintxt, string((*sipsp.PsipURI)(&au).Flat(plaintxt)))
+			_ = WithDebug && Dbg("decrypted URI: %v %s", plaintxt, string((*sipsp.PsipURI)(&au).Flat(plaintxt)))
 			uri := sipsp.PsipURI(au)
 			if !bytes.Equal(uris[i], uri.Flat(plaintxt)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, uris[i], string(uri.Flat(plaintxt)))
@@ -204,24 +202,24 @@ func TestUriCBCEncrypt(t *testing.T) {
 	})
 	t.Run("static memory", func(t *testing.T) {
 		for i, u := range pUris {
-			Dbg("test case uri: %s", string(uris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
 			au := AnonymURI(u)
 			l, err := au.PKCSPaddedLen(cipher.User.Encrypter.BlockSize())
 			if err != nil {
 				t.Fatalf("cannot compute URI pad len %s: %s", uris[i], err.Error())
 			}
-			Dbg("padded len: %d", l)
+			_ = WithDebug && Dbg("padded len: %d", l)
 			ciphertxt := EncryptBuf()
 			if err := au.CBCEncrypt(ciphertxt, uris[i]); err != nil {
 				t.Fatalf("cannot encrypt URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("encrypted URI: %v (len: %d)", ciphertxt, len(ciphertxt))
+			_ = WithDebug && Dbg("encrypted URI: %v (len: %d)", ciphertxt, len(ciphertxt))
 			plaintxt := DecryptBuf()
 			if err := au.CBCDecrypt(plaintxt, ciphertxt); err != nil {
-				Dbg("decrypted URI: %v", plaintxt)
+				_ = WithDebug && Dbg("decrypted URI: %v", plaintxt)
 				t.Fatalf("cannot decrypt URI %s: %s", uris[i], err.Error())
 			}
-			Dbg("decrypted URI: %v %s", plaintxt, string((*sipsp.PsipURI)(&au).Flat(plaintxt)))
+			_ = WithDebug && Dbg("decrypted URI: %v %s", plaintxt, string((*sipsp.PsipURI)(&au).Flat(plaintxt)))
 			uri := sipsp.PsipURI(au)
 			if !bytes.Equal(uris[i], uri.Flat(plaintxt)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, uris[i], string(uri.Flat(plaintxt)))
@@ -230,25 +228,25 @@ func TestUriCBCEncrypt(t *testing.T) {
 	})
 	t.Run("host only", func(t *testing.T) {
 		for i, u := range pUrisPPH {
-			Dbg("test case uri: %s", string(urisPPH[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(urisPPH[i]))
 			au := AnonymURI(u)
 			l, err := au.PKCSPaddedLen(cipher.User.Encrypter.BlockSize())
 			if err != nil {
 				t.Fatalf("cannot compute URI pad len %s: %s", urisPPH[i], err.Error())
 			}
-			Dbg("padded len: %d", l)
+			_ = WithDebug && Dbg("padded len: %d", l)
 			ciphertxt := EncryptBuf()
 			// host only encryption
 			if err := au.CBCEncrypt(ciphertxt, urisPPH[i], true); err != nil {
 				t.Fatalf("cannot encrypt URI %s: %s", urisPPH[i], err.Error())
 			}
-			Dbg("encrypted URI: %v (len: %d)", ciphertxt, len(ciphertxt))
+			_ = WithDebug && Dbg("encrypted URI: %v (len: %d)", ciphertxt, len(ciphertxt))
 			plaintxt := DecryptBuf()
 			if err := au.CBCDecrypt(plaintxt, ciphertxt); err != nil {
-				Dbg("decrypted URI: %v", plaintxt)
+				_ = WithDebug && Dbg("decrypted URI: %v", plaintxt)
 				t.Fatalf("cannot decrypt URI %s: %s", urisPPH[i], err.Error())
 			}
-			Dbg("decrypted URI: %v %s", plaintxt, string((*sipsp.PsipURI)(&au).Flat(plaintxt)))
+			_ = WithDebug && Dbg("decrypted URI: %v %s", plaintxt, string((*sipsp.PsipURI)(&au).Flat(plaintxt)))
 			uri := sipsp.PsipURI(au)
 			if !bytes.Equal(urisPPH[i], uri.Flat(plaintxt)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, urisPPH[i], string(uri.Flat(plaintxt)))
@@ -303,19 +301,19 @@ func TestUriAnonymization(t *testing.T) {
 	// tests
 	t.Run("CBC state", func(t *testing.T) {
 		for i, u := range pUris {
-			Dbg("test case uri: %s", string(uris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
 			au := AnonymURI(u)
 			anon := AnonymizeBuf()
 			if err := au.Anonymize(anon, uris[i], true); err != nil {
 				t.Fatalf("could not anonymize SIP URI %s: %s", uris[i], err)
 			}
-			Dbg("anonymized uri: %v %s", anon, string((*sipsp.PsipURI)(&au).Flat(anon)))
+			_ = WithDebug && Dbg("anonymized uri: %v %s", anon, string((*sipsp.PsipURI)(&au).Flat(anon)))
 			dupAnon := make([]byte, len(anon))
 			dupAu := AnonymURI(u)
 			if err := dupAu.Anonymize(dupAnon, uris[i], true); err != nil {
 				t.Fatalf("could not anonymize SIP URI %s: %s", uris[i], err)
 			}
-			Dbg("duplicated anonymized uri: %v %s", dupAnon, string((*sipsp.PsipURI)(&dupAu).Flat(dupAnon)))
+			_ = WithDebug && Dbg("duplicated anonymized uri: %v %s", dupAnon, string((*sipsp.PsipURI)(&dupAu).Flat(dupAnon)))
 			if !bytes.Equal((*sipsp.PsipURI)(&au).Flat(anon), (*sipsp.PsipURI)(&au).Flat(dupAnon)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, (*sipsp.PsipURI)(&au).Flat(anon), (*sipsp.PsipURI)(&au).Flat(dupAnon))
 			}
@@ -323,18 +321,18 @@ func TestUriAnonymization(t *testing.T) {
 	})
 	t.Run("everything", func(t *testing.T) {
 		for i, u := range pUris {
-			Dbg("test case uri: %s", string(uris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
 			au := AnonymURI(u)
 			anon := AnonymizeBuf()
 			if err := au.Anonymize(anon, uris[i]); err != nil {
 				t.Fatalf("could not anonymize SIP URI %s: %s", uris[i], err)
 			}
-			Dbg("anonymized uri: %v %s", anon, string((*sipsp.PsipURI)(&au).Flat(anon)))
+			_ = WithDebug && Dbg("anonymized uri: %v %s", anon, string((*sipsp.PsipURI)(&au).Flat(anon)))
 			deanon := DeanonymizeBuf()
 			if err := au.Deanonymize(deanon, anon); err != nil {
 				t.Fatalf("could not deanonymize SIP URI %s: %s", string((*sipsp.PsipURI)(&au).Flat(anon)), err)
 			}
-			Dbg("deanonymized uri: %v %s", deanon, string((*sipsp.PsipURI)(&au).Flat(deanon)))
+			_ = WithDebug && Dbg("deanonymized uri: %v %s", deanon, string((*sipsp.PsipURI)(&au).Flat(deanon)))
 			if !bytes.Equal(uris[i], (*sipsp.PsipURI)(&au).Flat(deanon)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, uris[i], string((*sipsp.PsipURI)(&au).Flat(deanon)))
 			}
@@ -342,18 +340,18 @@ func TestUriAnonymization(t *testing.T) {
 	})
 	t.Run("host only", func(t *testing.T) {
 		for i, u := range pUris {
-			Dbg("test case uri: %s", string(uris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
 			au := AnonymURI(u)
 			anon := AnonymizeBuf()
 			if err := au.Anonymize(anon, uris[i], true); err != nil {
 				t.Fatalf("could not anonymize SIP URI %s: %s", uris[i], err)
 			}
-			Dbg("anonymized uri: %v %s", anon, string((*sipsp.PsipURI)(&au).Flat(anon)))
+			_ = WithDebug && Dbg("anonymized uri: %v %s", anon, string((*sipsp.PsipURI)(&au).Flat(anon)))
 			deanon := DeanonymizeBuf()
 			if err := au.Deanonymize(deanon, anon); err != nil {
 				t.Fatalf("could not deanonymize SIP URI %s: %s", string((*sipsp.PsipURI)(&au).Flat(anon)), err)
 			}
-			Dbg("deanonymized uri: %v %s", deanon, string((*sipsp.PsipURI)(&au).Flat(deanon)))
+			_ = WithDebug && Dbg("deanonymized uri: %v %s", deanon, string((*sipsp.PsipURI)(&au).Flat(deanon)))
 			if !bytes.Equal(uris[i], (*sipsp.PsipURI)(&au).Flat(deanon)) {
 				t.Fatalf(`expected: "%s" got: "%s"`, uris[i], string((*sipsp.PsipURI)(&au).Flat(deanon)))
 			}
@@ -439,13 +437,13 @@ func TestUriAnonymization(t *testing.T) {
 			}
 		}
 		for i, u := range pAnonUris {
-			Dbg("test case uri: %s", string(anonUris[i]))
+			_ = WithDebug && Dbg("test case uri: %s", string(anonUris[i]))
 			au := AnonymURI(u)
 			deanon := DeanonymizeBuf()
 			if err := au.Deanonymize(deanon, anonUris[i]); err != nil {
 				t.Fatalf("could not deanonymize SIP URI %s: %s", anonUris[i], err)
 			}
-			Dbg("deanonymized uri: %v %s", deanon, string((*sipsp.PsipURI)(&au).Flat(deanon)))
+			_ = WithDebug && Dbg("deanonymized uri: %v %s", deanon, string((*sipsp.PsipURI)(&au).Flat(deanon)))
 		}
 	})
 }

--- a/uri_test.go
+++ b/uri_test.go
@@ -267,7 +267,7 @@ func TestUriAnonymization(t *testing.T) {
 	GenerateKeyFromPassphraseAndCopy(pass, EncryptionKeyLen, encKey[:])
 
 	// initialize the URI CBC based encryption
-	InitUriKeysFromMasterKey(encKey[:], EncryptionKeyLen)
+	InitUriKeysFromMasterKey(encKey[:])
 	NewUriCBC(GetUriKeys())
 	// test case data
 	uris := [...][]byte{
@@ -364,7 +364,7 @@ func TestUriAnonymization(t *testing.T) {
 		//pass := "foobar"
 		GenerateKeyFromPassphraseAndCopy(pass, EncryptionKeyLen, encKey[:])
 		// generate IV for CBC
-		InitUriKeysFromMasterKey(encKey[:], EncryptionKeyLen)
+		InitUriKeysFromMasterKey(encKey[:])
 		NewUriCBC(GetUriKeys())
 		anonUris := [...][]byte{
 			//[]byte("sip:7FIQTTVPC65OONS0H7B1O9EAE8------@86O14ERFB383DT1IOALB79L798------"),
@@ -459,7 +459,7 @@ func BenchmarkUriAnonymization(b *testing.B) {
 	GenerateKeyFromPassphraseAndCopy(pass, EncryptionKeyLen, encKey[:])
 
 	// initialize the URI CBC based encryption
-	InitUriKeysFromMasterKey(encKey[:], EncryptionKeyLen)
+	InitUriKeysFromMasterKey(encKey[:])
 	NewUriCBC(GetUriKeys())
 	// test case data
 	uris := [...][]byte{

--- a/validation.go
+++ b/validation.go
@@ -189,12 +189,12 @@ func (vtor *KeyValidator) Validate(code string) (isValid bool) {
 		return false
 	}
 	if kvRemote.withNonce {
-		Dbg("compute with nonce:%d", kvRemote.nonce)
+		_ = WithDebug && Dbg("compute with nonce:%d", kvRemote.nonce)
 		kvLocal = vtor.computeWithSaltAndNonce(kvRemote.salt, kvRemote.nonce)
 	} else {
 		kvLocal = vtor.computeWithSaltAndNonce(kvRemote.salt)
 	}
-	Dbg("remote: \"%s\" local: \"%s\"", code, kvLocal.String())
+	_ = WithDebug && Dbg("remote: \"%s\" local: \"%s\"", code, kvLocal.String())
 	isValid = (subtle.ConstantTimeCompare([]byte(code), []byte(kvLocal.String())) == 1)
 	return
 }
@@ -207,7 +207,7 @@ func (vtor *KeyValidator) Code() string {
 // Format: hexadecimal_hmac:salt:[:base10_32bit_nonce]
 func (kv *KeyValidation) Bytes() []byte {
 	dstLen := hex.EncodedLen(len(kv.code)) + 1 + len(kv.salt) + 1 + MaxUintLen
-	Dbg("dstLen: %d", dstLen)
+	_ = WithDebug && Dbg("dstLen: %d", dstLen)
 	dst := make([]byte, dstLen)
 	// hexadecimal encoding of the mac
 	n := hex.Encode(dst, kv.code)
@@ -221,7 +221,7 @@ func (kv *KeyValidation) Bytes() []byte {
 	length++
 	dst = append(dst[0:length], kv.salt...)
 	length += len(kv.salt)
-	Dbg("length: %d", length)
+	_ = WithDebug && Dbg("length: %d", length)
 	if kv.withNonce {
 		dst = append(dst[0:length], ':')
 		length++
@@ -245,7 +245,7 @@ func registerHashFunctions() {
 func (kv *KeyValidation) parseCode(code string) (err error) {
 	err = nil
 	s := strings.Split(code, Separator)
-	Dbg("len:%d %q", len(s), s)
+	_ = WithDebug && Dbg("len:%d %q", len(s), s)
 	kv.withNonce = false
 	switch len(s) {
 	case 2:

--- a/with-debug.go
+++ b/with-debug.go
@@ -1,0 +1,7 @@
+// +build debug
+
+package anonymization
+
+const (
+	WithDebug = true
+)

--- a/without-debug.go
+++ b/without-debug.go
@@ -1,0 +1,7 @@
+// +build !debug
+
+package anonymization
+
+const (
+	WithDebug = false
+)


### PR DESCRIPTION
Preserve the prefix of IP addresses during anonymization.
See research paper here for details:
http://conferences.sigcomm.org/imc/2001/imw2001-papers/69.pdf
issues:
- https://github.com/intuitivelabs/intuitive-issues/issues/470

See related js PR:
- https://github.com/intuitivelabs/anonym-js/pull/11