### PR TITLE
fixes URI PAN decrypt

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -19,6 +19,7 @@ type Codec int
 const (
 	Base32 Codec = iota
 	Hex
+	InvalidCodec
 )
 
 type Encoding interface {

--- a/uri_test.go
+++ b/uri_test.go
@@ -412,7 +412,7 @@ func TestUriAnonymization(t *testing.T) {
 		au.WithPan()
 		for i, u := range uris {
 			_ = WithDebug && Dbg("test case uri: %s", string(uris[i]))
-			anonBuf := AnonymizeBuf()
+			anonBuf := AnonymizeBuf(len(u))
 			res, err := au.Anonymize(anonBuf, u)
 			if err != nil {
 				t.Fatalf("could not anonymize SIP URI %s: %s", uris[i], err)


### PR DESCRIPTION
- decoding/decrypt algoritms have to be changed dynamically based on the
  anonymization type of the URI; anonymization type is encoded in the
  first ASCII character of the URI's username